### PR TITLE
return params text in key=value format

### DIFF
--- a/src/tableau_api_lib/api_endpoints/base_endpoint.py
+++ b/src/tableau_api_lib/api_endpoints/base_endpoint.py
@@ -22,7 +22,7 @@ class BaseEndpoint:
     @property
     def _params_text(self):
         if self._parameter_dict:
-            return list(self._parameter_dict.values())
+            return [f'{k}={v}' for k, v in self._parameter_dict.items()]
         else:
             return []
 


### PR DESCRIPTION
the url parameters should be in the format key=value.

Addresses https://github.com/divinorum-webb/tableau-api-lib/issues/13

Right now when you pass a dict to parameter dict the only thing that appends is the value from the dictionary, this should append the key, value pairs in the correct format. 