### PR TITLE
fix for parameter_dict issue #54

### DIFF
--- a/src/tableau_api_lib/api_endpoints/base_endpoint.py
+++ b/src/tableau_api_lib/api_endpoints/base_endpoint.py
@@ -34,7 +34,8 @@ class BaseEndpoint:
         text_to_append = "?" if any(self._params_exist) else ""
         for i, text in enumerate(self._params_text):
             if self._params_exist[i]:
-                text_to_append += text if text_to_append.endswith('?') else ('&' + text)
+                parameter_text = self._params_exist[i]+'='+text
+                text_to_append += parameter_text if text_to_append.endswith('?') else ('&' + parameter_text)
         return "{0}{1}".format(url, text_to_append)
     
     def _invalid_parameter_exception(self):


### PR DESCRIPTION
#### Reference Issues/PRs
 
Issue #54 parameter_dict not working for get_users_on_site()

#### What does this implement/fix? Explain your changes.

Updated the _append_url_parameters() in /src/tableau_api_lib/api_endpoints/base_endpoint.py to append the parameters passed in parameter_dict in 'key=value' format instead of 'value'. 

#### Any other comments?

No

