### PR TITLE
Replace deprecated df.append() Pandas call with pd.concat

### DIFF
--- a/src/tableau_api_lib/utils/querying/workbooks.py
+++ b/src/tableau_api_lib/utils/querying/workbooks.py
@@ -114,5 +114,5 @@ def get_embedded_datasources_dataframe(
         workbook_connections_df[new_col_prefix + "workbook_name"] = workbook[name_col]
         workbook_connections_df[new_col_prefix + "workbook_id"] = workbook[id_col]
         workbook_connections_df[new_col_prefix + "site_name"] = conn.site_name
-        embedded_datasources_df = embedded_datasources_df.append(workbook_connections_df, ignore_index=True, sort=True)
+        embedded_datasources_df = pd.concat([embedded_datasources_df, workbook_connections_df], ignore_index=True, sort=True)
     return embedded_datasources_df


### PR DESCRIPTION
Pandas version 1.4 [depreciated the df.append()](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append) method and pd.concat() is now preferred.  This now produces DepreciationWarnings whenever this function is called.

Figured I'd quickly make the change -- happy to accept feedback or close if this is desired behavior.