### PR TITLE
Add flow run endpoints

### DIFF
--- a/src/tableau_api_lib/api_endpoints/__init__.py
+++ b/src/tableau_api_lib/api_endpoints/__init__.py
@@ -5,6 +5,7 @@ from .datasource_endpoint import DatasourceEndpoint
 from .favorites_endpoint import FavoritesEndpoint
 from .file_upload_endpoint import FileUploadEndpoint
 from .flow_endpoint import FlowEndpoint
+from .flow_run_endpoint import FlowRunEndpoint
 from .group_endpoint import GroupEndpoint
 from .jobs_endpoint import JobsEndpoint
 from .permissions_endpoint import PermissionsEndpoint

--- a/src/tableau_api_lib/api_endpoints/flow_run_endpoint.py
+++ b/src/tableau_api_lib/api_endpoints/flow_run_endpoint.py
@@ -1,0 +1,65 @@
+from tableau_api_lib.api_endpoints import BaseEndpoint
+
+
+class FlowRunEndpoint(BaseEndpoint):
+    def __init__(
+        self,
+        ts_connection,
+        flow_run_id=None,
+        get_flow_runs=False,
+        get_flow_run=False,
+        cancel_flow_run=False,
+        parameter_dict=None,
+    ):
+        """
+        Builds API endpoints for REST API flow methods.
+        :param class ts_connection: the Tableau Server connection object
+        :param str flow_run_id: the flow run ID relevant to queries
+        :param bool get_flow_runs: True if querying flow runs
+        :param bool get_flow_run: True if getting info about specified flow run
+        :param bool cancel_flow_run: True if canceling specified flow run
+        :param dict parameter_dict: dictionary of URL parameters to append. The value in each key-value pair is the literal
+        text that will be appended to the URL endpoint
+        """
+
+        super().__init__(ts_connection)
+        self._flow_run_id = flow_run_id
+        self._get_flow_runs = get_flow_runs
+        self._get_flow_run = get_flow_run
+        self._cancel_flow_run = cancel_flow_run
+        self._parameter_dict = parameter_dict
+        self._validate_inputs()
+
+    @property
+    def mutually_exclusive_params(self):
+        return [
+            self._get_flow_runs,
+            self._get_flow_run,
+            self._cancel_flow_run
+        ]
+
+    def _validate_inputs(self) -> None:
+        valid = True
+        if sum(self.mutually_exclusive_params) != 1:
+            valid = False
+        if not valid:
+            self._invalid_parameter_exception()
+
+    @property
+    def base_flow_runs_url(self):
+        return "{0}/api/{1}/sites/{2}/flows/runs".format(
+            self._connection.server, self._connection.api_version, self._connection.site_id
+        )
+
+    @property
+    def base_flow_run_url(self):
+        return "{0}/{1}".format(self.base_flow_runs_url, self._flow_run_id)
+
+    def get_endpoint(self):
+        url = None
+        if self._flow_run_id:
+            url = self.base_flow_run_url
+        else:
+            url = self.base_flow_runs_url
+
+        return self._append_url_parameters(url)

--- a/src/tableau_api_lib/tableau_server_connection.py
+++ b/src/tableau_api_lib/tableau_server_connection.py
@@ -2963,6 +2963,51 @@ class TableauServerConnection:
         response = self._set_response_encoding(response=response)
         return response
 
+    @decorators.verify_api_method_exists("3.1")
+    def get_flow_runs(self, parameter_dict: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Queries site to obtain information for flow runs"""
+        self.active_endpoint = api_endpoints.FlowRunEndpoint(
+            ts_connection=self, get_flow_runs=True, parameter_dict=parameter_dict
+        ).get_endpoint()
+        self.active_headers = self.default_headers
+        response = requests.get(
+            url=self.active_endpoint,
+            headers=self.active_headers,
+            verify=self.ssl_verify,
+        )
+        response = self._set_response_encoding(response=response)
+        return response
+
+    @decorators.verify_api_method_exists("3.1")
+    def get_flow_run(self, flow_run_id: str, parameter_dict: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Gets information about specified flow run"""
+        self.active_endpoint = api_endpoints.FlowRunEndpoint(
+            ts_connection=self, flow_run_id=flow_run_id, get_flow_run=True, parameter_dict=parameter_dict
+        ).get_endpoint()
+        self.active_headers = self.default_headers
+        response = requests.get(
+            url=self.active_endpoint,
+            headers=self.active_headers,
+            verify=self.ssl_verify,
+        )
+        response = self._set_response_encoding(response=response)
+        return response
+
+    @decorators.verify_api_method_exists("3.1")
+    def cancel_flow_run(self, flow_run_id: str, parameter_dict: Optional[Dict[str, Any]] = None) -> requests.Response:
+        """Cancels specified flow run"""
+        self.active_endpoint = api_endpoints.FlowRunEndpoint(
+            ts_connection=self, flow_run_id=flow_run_id, cancel_flow_run=True, parameter_dict=parameter_dict
+        ).get_endpoint()
+        self.active_headers = self.default_headers
+        response = requests.put(
+            url=self.active_endpoint,
+            headers=self.active_headers,
+            verify=self.ssl_verify,
+        )
+        response = self._set_response_encoding(response=response)
+        return response
+
     def run_flow_task(self, task_id):
         """
         Runs the specified flow run task.


### PR DESCRIPTION
Add ability to work with flow run endpoints to the API library. These are useful for checking up on a running flow's status (e.g. after using the "run_flow_now" method).

I have attempted to adhere to the current library's implementation and standard as best as possible, please feel free to make edits and contact me at aldin@apple.com if there are any questions.

Link to Tableau REST API documentation for reference: https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_flow.htm#get_flow_run